### PR TITLE
Install charty without --pre

### DIFF
--- a/datascience/Dockerfile
+++ b/datascience/Dockerfile
@@ -115,6 +115,7 @@ ENV PATH $HOME/.gem/ruby/2.6.0/bin:$PATH
 RUN gem install \
         activerecord \
         awesome_print \
+        charty \
         daru \
         daru-view \
         ffi-rzmq \
@@ -144,7 +145,5 @@ RUN gem install \
         red-plasma \
         rumale \
         sqlite3 \
-    && gem install --pre \
-           charty \
     \
     && iruby register

--- a/how_to_select.md
+++ b/how_to_select.md
@@ -24,6 +24,7 @@ These two images contain the same Ruby component for data science:
 - red-arrow-nmatrix
 - daru
 - rbplotly
+- charty
 
 ## `rubydata/minimal-notebook`
 

--- a/minimal/Dockerfile
+++ b/minimal/Dockerfile
@@ -115,6 +115,7 @@ ENV PATH $HOME/.gem/ruby/2.6.0/bin:$PATH
 RUN gem install \
         activerecord \
         awesome_print \
+        charty \
         daru \
         daru-view \
         ffi-rzmq \
@@ -144,7 +145,5 @@ RUN gem install \
         red-plasma \
         rumale \
         sqlite3 \
-    && gem install --pre \
-           charty \
     \
     && iruby register

--- a/minimal/README.md
+++ b/minimal/README.md
@@ -19,7 +19,7 @@ This docker image consists of minimal components for data science using Ruby.
     patsy, cloudpickle, dill, numba, xray, pyarrow, tensorflow, keras,
     chainer, xgboost
 - Ruby stack
-  - pry, iruby, pycall, numpy, pandas, matplotlib, numo-narray, numo-linalg, nmatrix, nmatrix-lapacke, red-arrow, red-arrow-numo-narray, red-arrow-nmatrix, daru, rbplotly
+  - pry, iruby, pycall, numpy, pandas, matplotlib, numo-narray, numo-linalg, nmatrix, nmatrix-lapacke, red-arrow, red-arrow-numo-narray, red-arrow-nmatrix, daru, rbplotly, charty
 
 ## Basic Usage
 


### PR DESCRIPTION
Charty v0.2.0 has released. we can install charty without --pre option.

https://rubygems.org/gems/charty/versions/0.2.0